### PR TITLE
fix(a11y): add titleOptions prop to SidebarBlock

### DIFF
--- a/src/components/layout/SidebarBlock.jsx
+++ b/src/components/layout/SidebarBlock.jsx
@@ -1,22 +1,40 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 
-const SidebarBlock = props => (
-  <div className={props.className}>
-    {props.title && <h4 className="mb-2">{props.title}</h4>}
-    {props.children}
-  </div>
-);
+const SidebarBlock = ({
+  className,
+  title,
+  children,
+  titleOptions,
+}) => {
+  const { tag: TitleTag } = titleOptions;
+  return (
+    <div className={className}>
+      {title && (
+        <TitleTag className={classNames('mb-2', titleOptions.className)}>
+          {title}
+        </TitleTag>
+      )}
+      {children}
+    </div>
+  );
+};
 
 SidebarBlock.propTypes = {
-  title: PropTypes.string,
   children: PropTypes.node.isRequired,
+  title: PropTypes.string,
   className: PropTypes.string,
+  titleOptions: PropTypes.shape({
+    tag: PropTypes.string,
+    className: PropTypes.string,
+  }),
 };
 
 SidebarBlock.defaultProps = {
   title: null,
   className: undefined,
+  titleOptions: { tag: 'h4', className: undefined },
 };
 
 export default SidebarBlock;


### PR DESCRIPTION
An a11y issue I found was that we were skipping a heading level in `frontend-app-learner-portal-enterprise`, e.g. using a `<h2>` in the main content area and then using an `<h4>` in the sidebar (skipping an `<h3>`).

This PR adds a prop `titleOptions` to the `SidebarBlock` component to be able to configure that tag used for the sidebar block title and a custom class name. That way, you can now specify that you want the title to be an `<h3>` tag but styled with a `className` of `h4`.