### PR TITLE
Make masters/programs owners in openedx.yaml

### DIFF
--- a/openedx.yaml
+++ b/openedx.yaml
@@ -1,4 +1,4 @@
 # openedx.yaml
 
 ---
-owner: edx/business-enterprise-team
+owner: edx/masters-all


### PR DESCRIPTION
Pass repo ownership to programs/masters now that the enterprise portal is moving away from gatsby