### PR TITLE
update openedx.yaml to use current best practices

### DIFF
--- a/openedx.yaml
+++ b/openedx.yaml
@@ -1,4 +1,3 @@
-# openedx.yaml
-
+# This file describes this Open edX repo, as described in OEP-2:
+# https://open-edx-proposals.readthedocs.io/en/latest/oep-0002-bp-repo-metadata.html#specification
 ---
-owner: edx/masters-all


### PR DESCRIPTION
Remove deprecated fields from openedx.yaml, per the [OEP](https://open-edx-proposals.readthedocs.io/en/latest/oep-0002-bp-repo-metadata.html). The ownership document should the single source of truth for ownership information.

Note: I'm leaving the `openedx.yaml` file blank here since this repository is on its way out. 