### PR TITLE
chore: add repository URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,8 +94,5 @@
   },
   "keywords": [],
   "license": "AGPL",
-  "repository": {
-    "type": "git",
-    "url": ""
-  }
+  "repository": "https://github.com/edx/frontend-learner-portal-base"
 }


### PR DESCRIPTION
Adds a repository URL so tooling such as Paragon Usage Insights can properly link to this repository.